### PR TITLE
set log level for urllib3

### DIFF
--- a/src/cassandras3/log.py
+++ b/src/cassandras3/log.py
@@ -7,6 +7,7 @@ def setup_logging(level=logging.DEBUG):  # pragma: no cover
     logging.basicConfig(level=logging.DEBUG,
                         format='%(asctime)s - %(levelname)s - %(message)s')
     logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    logging.getLogger('urllib3').setLevel(logging.CRITICAL)
     logging.getLogger('botocore').setLevel(logging.CRITICAL)
     logging.getLogger('s3transfer').setLevel(logging.CRITICAL)
     logging.getLogger('sh').setLevel(logging.CRITICAL)


### PR DESCRIPTION
In the case of a lot of debug logs in the script output, we would like to set the log level for `urllib3` to `logging.CRITICAL`.
Unexpected output example:
```
DEBUG - Converted retries value: False -> Retry(total=False, connect=None, read=None, redirect=0, status=None)
2019-07-08 14:37:48,043 - DEBUG - https://... HTTP/1.1" 200 0
```